### PR TITLE
Adding backwards compatibility for PHP versions < 5.4

### DIFF
--- a/lib/BFPHPClient/BillingEntity.php
+++ b/lib/BFPHPClient/BillingEntity.php
@@ -10,12 +10,12 @@ abstract class Bf_BillingEntity extends \ArrayObject {
 
 	protected $_client = NULL;
 
-	protected $_registeredEntities = [];
-	protected $_registeredEntityArrays = [];
+	protected $_registeredEntities = array();
+	protected $_registeredEntityArrays = array();
 
 	public function __construct(BfClient &$client = NULL, array $stateParams = NULL) {
 		if ($stateParams == NULL) {
-			$stateParams = [];
+			$stateParams = array();
 		}
 
 		$this->setClient($client);
@@ -58,7 +58,7 @@ abstract class Bf_BillingEntity extends \ArrayObject {
 	}
 
 	protected function buildEntityArray($class, array $input) {
-		$entityArray = [];
+		$entityArray = array();
 		foreach ($input as $index => $value) {
 			$newEntity = $this->buildEntity($class, $value);
 			$entityArray[$index] = $newEntity;
@@ -92,7 +92,7 @@ abstract class Bf_BillingEntity extends \ArrayObject {
 	}
 
 	public function getSerialized() {
-		$outputArray = [];
+		$outputArray = array();
 		foreach ($this as $key => $value) {
 			$outputArray[$key] = static::serializeField($value);
 		}
@@ -105,7 +105,7 @@ abstract class Bf_BillingEntity extends \ArrayObject {
 			return $value->getSerialized();
 		} else if (is_array($value)) {
 			// if it's an array of entities (or worse)?
-			$tempArray = [];
+			$tempArray = array();
 			// recursively serialize its contents, and return them
 			foreach ($value as $key2 => $value2) {
 				$tempArray[$key2] = static::serializeField($value2);

--- a/lib/BFPHPClient/Controller.php
+++ b/lib/BFPHPClient/Controller.php
@@ -46,7 +46,7 @@ abstract class Bf_Controller {
 		$json = $response->json();
 		$results = $json['results'];
 
-		$entities = [];
+		$entities = array();
 
 		foreach($results as $value) {
 			$constructedEntity = new $entityClass($client, $value);
@@ -63,7 +63,7 @@ abstract class Bf_Controller {
 	 */
 	public function create(array $stateParams = NULL) {
 		if ($stateParams == NULL) {
-			$stateParams = [];
+			$stateParams = array();
 		}
 		$entityClass = static::getEntityClass();
 

--- a/lib/BFPHPClient/OrganisationController.php
+++ b/lib/BFPHPClient/OrganisationController.php
@@ -18,7 +18,7 @@ class Bf_OrganisationController extends Bf_Controller {
 		$json = $response->json();
 		$results = $json['results'];
 
-		$entities = [];
+		$entities = array();
 
 		foreach($results as $value) {
 			$constructedEntity = new $entityClass($client, $value);


### PR DESCRIPTION
See [docs for arrays](http://php.net/manual/en/language.types.array.php). Instantiating an array with `[]` is a newer feature and isn't compatible with all PHP versions. Using the older `array()` syntax allows more compatibility.
